### PR TITLE
Use original haproxy directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY rsyslog.conf /etc/rsyslog.d/
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
-CMD [ "-f", "/usr/local/haproxy/haproxy.cfg" ]
+CMD [ "-f", "/usr/local/etc/haproxy/haproxy.cfg" ]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This image uses latest Alpine-based HAProxy image, starts rsyslog and provides s
 
 ### Configuration
 
-To use stdout logging with your Docker container, please use this snippet in your HAProxy config: 
+To use stdout logging with your Docker container, please use this snippet in your HAProxy config:
 
 ```
 global
@@ -26,7 +26,7 @@ docker run -d \
            --rm \
            -p <host port>:<container port> \
            -p <host port>:<container port> \
-           -v /path/to/haproxy/config:/usr/local/haproxy/haproxy.cfg:ro \
+           -v /path/to/haproxy/config:/usr/local/etc/haproxy/haproxy.cfg:ro \
            --name haproxy \
            mminks/haproxy-docker-logging
 ```


### PR DESCRIPTION
Hi! Thanks for awesome docker image.
I had problem using this image instead of official haproxy because of non-conventional path to haproxy directory. `/usr/local/haproxy` instead of `/usr/local/etc/haproxy`. My guess this is typo, which I fixed in my humble PR.