### PR TITLE
Allow haproxy config reloading

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,7 @@ start_rsyslogd() {
 }
 
 start_lb() {
-  exec haproxy "$@"
+  exec haproxy -W -db "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Sorry to bother you again.

As readme states, haproxy config can be reloaded with SIGHUP. But it doesn't work unless you run haproxy in master worker mode (-W flag). Official haproxy image does that https://github.com/docker-library/haproxy/blob/9da24940385e6178f987737305ff499734437c90/1.8/alpine/docker-entrypoint.sh#L14.

This is big deal in my opinion and another incompatibility with official image. So, what you think about adding same flags?